### PR TITLE
add handoff limit to tools; update .gitignore and add langgraph.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# LangGrah
+.langgraph_api
+
 # Pyenv
 .python-version
 

--- a/examples/customer_support.py
+++ b/examples/customer_support.py
@@ -8,6 +8,7 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.prebuilt import create_react_agent
 
 from langgraph_swarm import create_handoff_tool, create_swarm
+from langgraph_swarm.swarm import SwarmState
 
 model = ChatOpenAI(model="gpt-4o")
 
@@ -116,6 +117,7 @@ flight_assistant = create_react_agent(
     [search_flights, book_flight, transfer_to_hotel_assistant],
     prompt=make_prompt("You are a flight booking assistant"),
     name="flight_assistant",
+    state_schema=SwarmState,
 )
 
 hotel_assistant = create_react_agent(
@@ -123,6 +125,7 @@ hotel_assistant = create_react_agent(
     [search_hotels, book_hotel, transfer_to_flight_assistant],
     prompt=make_prompt("You are a hotel booking assistant"),
     name="hotel_assistant",
+    state_schema=SwarmState,
 )
 
 # Compile and run!

--- a/langgraph.json
+++ b/langgraph.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": ["."],
+  "graphs": {
+    "app": "./examples/customer_support.py:app"
+  },
+  "env": ".env"
+}

--- a/langgraph_swarm/swarm.py
+++ b/langgraph_swarm/swarm.py
@@ -1,15 +1,16 @@
 from typing import Type, TypeVar
 
-from langgraph.graph import START, MessagesState, StateGraph
+from langgraph.graph import START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
+from langgraph.prebuilt.chat_agent_executor import AgentState
 
 from langgraph_swarm.handoff import get_handoff_destinations
 
 
-class SwarmState(MessagesState):
+class SwarmState(AgentState):
     """State schema for the multi-agent swarm."""
-
     active_agent: str
+    handoff_counter: int
 
 
 StateSchema = TypeVar("StateSchema", bound=SwarmState)
@@ -66,6 +67,8 @@ def create_swarm(
     """
     if "active_agent" not in state_schema.__annotations__:
         raise ValueError("Missing required key 'active_agent' in state_schema")
+    if "handoff_counter" not in state_schema.__annotations__:
+        raise ValueError("Missing required key 'handoff_counter' in state_schema")
 
     builder = StateGraph(state_schema)
     add_active_agent_router(


### PR DESCRIPTION
Added handoff_limit so that agents cannot transfer to each other indefinitely. 

Using AgentState on SwarmState is necessary because of create_react_agent requirements on state_schema. This way, just by extending SwarmState the user can add all necessary keys and then pass to the create_react_agent function.