### PR TITLE
Fix 'StateGraph' object has no attribute 'schema' error

### DIFF
--- a/langgraph_swarm/swarm.py
+++ b/langgraph_swarm/swarm.py
@@ -121,7 +121,7 @@ def add_active_agent_router(
         )
         ```
     """
-    channels = builder.schemas[builder.schema]
+    channels = builder.schemas[builder.state_schema]
     if "active_agent" not in channels:
         raise ValueError("Missing required key 'active_agent' in in builder's state_schema")
 


### PR DESCRIPTION
Fix 'StateGraph' object has no attribute 'schema'

https://github.com/langchain-ai/langgraph-swarm-py/issues/85