### PR TITLE
fix: clean shared messages state in case of history overwrite

### DIFF
--- a/langgraph_swarm/handoff.py
+++ b/langgraph_swarm/handoff.py
@@ -2,8 +2,9 @@ import re
 from dataclasses import is_dataclass
 from typing import Annotated, Any
 
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import ToolMessage, RemoveMessage
 from langchain_core.tools import BaseTool, InjectedToolCallId, tool
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import InjectedState, ToolNode
 from langgraph.types import Command
@@ -84,7 +85,7 @@ def create_handoff_tool(
             goto=agent_name,
             graph=Command.PARENT,
             update={
-                "messages": [*_get_field(state, "messages"), tool_message],
+                "messages": [RemoveMessage(REMOVE_ALL_MESSAGES), *_get_field(state, "messages"), tool_message],
                 "active_agent": agent_name,
             },
         )


### PR DESCRIPTION
Because the `messages` field is cumulative, overwriting history in any of the swarm agents causes the history update (such as a message summary) to be appended to the end. For example:

**Agent 1:**

* Message 1
* Message 2
* Hand off to Agent 2

**Agent 2:**

* Message 1
* Message 2
* Hand off to Agent 2
* Message 3

Then Agent 2 overwrites the history:

* Summary
* Message 4

And when handing off back to Agent 1, this happens:

* Message 1
* Message 2
* Hand off to Agent 2
* Summary
* Message 4
* Hand off to Agent 1

This not only disrupts the flow of the conversation but also causes issues if the summary is a system message (such as in `langmem`'s `SummarizationNode`).

On the other hand, if history is not overwritten, everything continues to work correctly after changes made in this PR, since the "removed" messages will simply be replaced by identical ones.

Fixes #84.
